### PR TITLE
Suppress `EINVAL` occasionally being raised by `bus.transition()`

### DIFF
--- a/magicbus/base.py
+++ b/magicbus/base.py
@@ -352,8 +352,10 @@ class Bus(object):
                     self.publish(channel)
             finally:
                 self._state_transition_pipes.discard(pipe)
-                os.close(read_fd)
+                # NOTE: Closing the write file descriptor first
+                # NOTE: to prevent "Broken pipe" in `self._transition()`.
                 os.close(write_fd)
+                os.close(read_fd)
 
         # From http://psyco.sourceforge.net/psycoguide/bugs.html:
         # "The compiled machine code does not include the regular polling

--- a/magicbus/test/test_processbus.py
+++ b/magicbus/test/test_processbus.py
@@ -203,17 +203,6 @@ class TestBusMethod:
             'Bus state: EXITED'
         ])
 
-    @pytest.mark.xfail(
-        reason=r"""Fails intermittently with
-        Traceback (most recent call last):
-        File "D:\a\magicbus\magicbus\magicbus\base.py",
-             line 205, in _transition
-        os.write(write_fd, b'1')
-        OSError: [Errno 22] Invalid argument
-        """,
-        raises=AssertionError,
-        strict=False,  # Because it's flaky
-    )
     def test_wait(self):
         b = ProcessBus()
         self.log(b)


### PR DESCRIPTION
This will potentially mostly resolve some of the race conditions described in #16.