### PR TITLE
Use epoll for Bus.wait() when available

### DIFF
--- a/magicbus/base.py
+++ b/magicbus/base.py
@@ -15,12 +15,13 @@ import os
 import random
 try:
     import select
+except ImportError:
+    select = None
+else:
     try:
         epoll = select.epoll
     except AttributeError:
         epoll = None
-except ImportError:
-    select = None
 import sys
 import time
 import traceback as _traceback


### PR DESCRIPTION
This overcomes a limitation in `select.select(fd, [], [])` when value of fd >= 1024

Here is an example on how to reproduce error:
```python
>>> import os
>>> import magicbus

>>> while os.open("/dev/null", 0) < 1023: pass
>>> bus = magicbus.Bus()
>>> bus.wait('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../magicbus/magicbus/base.py", line 352, in wait
    _wait()
  File ".../magicbus/magicbus/base.py", line 325, in _wait
    r, w, x = select.select([read_fd], [], [], interval)
ValueError: filedescriptor out of range in select()
```

Should fix #21 