### PR TITLE
Make loggers handle `str` + `bytes` seamlessly

### DIFF
--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -30,7 +30,7 @@ class StreamLogger(SimplePlugin):
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
             else:
-                if isinstance(complete_msg, unicodestr):
+                if isinstance(complete_msg, str):
                     encoding = self.encoding or "utf-8"
                     complete_msg = complete_msg.encode(encoding, errors="backslashreplace")
 

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -2,7 +2,7 @@
 
 import datetime
 import sys
-
+import six
 from magicbus.plugins import SimplePlugin
 
 
@@ -30,7 +30,7 @@ class StreamLogger(SimplePlugin):
             if self.encoding is not None:
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
-
+            complete_msg = six.ensure_str(complete_msg)
             self.stream.write(complete_msg)
             self.stream.flush()
 

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -27,12 +27,9 @@ class StreamLogger(SimplePlugin):
             }
             complete_msg = self.format % params
 
-            if self.encoding is not None:
-                if isinstance(complete_msg, str):
-                    complete_msg = complete_msg.encode(self.encoding)
-            else:
-                if isinstance(complete_msg, bytes):
-                    complete_msg = complete_msg.decode('utf-8')
+            if isinstance(complete_msg, bytes):
+                encoding = 'utf-8' if self.encoding is None else self.encoding
+                complete_msg = complete_msg.decode(encoding)
 
             self.stream.write(complete_msg)
             self.stream.flush()

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -30,8 +30,10 @@ class StreamLogger(SimplePlugin):
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
             else:
-                if not isinstance(complete_msg, unicodestr):
-                    complete_msg = complete_msg.decode("utf-8")
+                if isinstance(complete_msg, unicodestr):
+                    encoding = self.encoding or "utf-8"
+                    complete_msg = complete_msg.encode(encoding, errors="backslashreplace")
+
             self.stream.write(complete_msg)
             self.stream.flush()
 

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -2,6 +2,7 @@
 
 import datetime
 import sys
+
 from magicbus.plugins import SimplePlugin
 
 
@@ -52,7 +53,7 @@ class StderrLogger(StreamLogger):
 class FileLogger(StreamLogger):
 
     def __init__(self, bus, filename=None, file=None,
-                 level=None, format=None, encoding='utf-8'):
+                 level=None, format=None, encoding='utf8'):
         self.filename = filename
         if file is None:
             if filename is None:

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -9,7 +9,7 @@ class StreamLogger(SimplePlugin):
 
     default_format = '[%(timestamp)s] (Bus %(bus)s) %(message)s\n'
 
-    def __init__(self, bus, stream, level=None, format=None, encoding=None):
+    def __init__(self, bus, stream, level=None, format=None, encoding='utf8'):
         SimplePlugin.__init__(self, bus)
         self.stream = stream
         self.level = level
@@ -51,7 +51,7 @@ class StderrLogger(StreamLogger):
 class FileLogger(StreamLogger):
 
     def __init__(self, bus, filename=None, file=None,
-                 level=None, format=None, encoding=None):
+                 level=None, format=None, encoding='utf8'):
         self.filename = filename
         if file is None:
             if filename is None:

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -29,32 +29,29 @@ class StreamLogger(SimplePlugin):
             if self.encoding is not None:
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
-            # else:
-            #     if not isinstance(complete_msg, unicodestr):
-            #         complete_msg = complete_msg.decode("utf-8")
+            else:
+                if not isinstance(complete_msg, unicodestr):
+                    complete_msg = complete_msg.decode("utf-8")
             self.stream.write(complete_msg)
             self.stream.flush()
 
 
 class StdoutLogger(StreamLogger):
 
-    # def __init__(self, bus, level=None, format=None, encoding=None):
-    def __init__(self, bus, level=None, format=None, encoding="utf-8"):
+    def __init__(self, bus, level=None, format=None, encoding=None):
         StreamLogger.__init__(self, bus, sys.stdout, level, format, encoding)
 
 
 class StderrLogger(StreamLogger):
 
-    # def __init__(self, bus, level=None, format=None, encoding=None):
-    def __init__(self, bus, level=None, format=None, encoding='utf-8'):
+    def __init__(self, bus, level=None, format=None, encoding=None):
         StreamLogger.__init__(self, bus, sys.stderr, level, format, encoding)
 
 
 class FileLogger(StreamLogger):
 
     def __init__(self, bus, filename=None, file=None,
-                 level=None, format=None, encoding='utf8'):
-                 # level=None, format=None, encoding='utf-8'):
+                 level=None, format=None, encoding='utf-8'):
         self.filename = filename
         if file is None:
             if filename is None:

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -32,7 +32,7 @@ class StreamLogger(SimplePlugin):
                     complete_msg = complete_msg.encode(self.encoding)
             else:
                 if isinstance(complete_msg, bytes):
-                    complete_msg = complete_msg.decode("utf-8")
+                    complete_msg = complete_msg.decode('utf-8')
 
             self.stream.write(complete_msg)
             self.stream.flush()

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -29,29 +29,32 @@ class StreamLogger(SimplePlugin):
             if self.encoding is not None:
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
-            else:
-                if not isinstance(complete_msg, unicodestr):
-                    complete_msg = complete_msg.decode("utf-8")
+            # else:
+            #     if not isinstance(complete_msg, unicodestr):
+            #         complete_msg = complete_msg.decode("utf-8")
             self.stream.write(complete_msg)
             self.stream.flush()
 
 
 class StdoutLogger(StreamLogger):
 
-    def __init__(self, bus, level=None, format=None, encoding=None):
+    # def __init__(self, bus, level=None, format=None, encoding=None):
+    def __init__(self, bus, level=None, format=None, encoding="utf-8"):
         StreamLogger.__init__(self, bus, sys.stdout, level, format, encoding)
 
 
 class StderrLogger(StreamLogger):
 
-    def __init__(self, bus, level=None, format=None, encoding=None):
+    # def __init__(self, bus, level=None, format=None, encoding=None):
+    def __init__(self, bus, level=None, format=None, encoding='utf-8'):
         StreamLogger.__init__(self, bus, sys.stderr, level, format, encoding)
 
 
 class FileLogger(StreamLogger):
 
     def __init__(self, bus, filename=None, file=None,
-                 level=None, format=None, encoding='utf-8'):
+                 level=None, format=None, encoding='utf8'):
+                 # level=None, format=None, encoding='utf-8'):
         self.filename = filename
         if file is None:
             if filename is None:

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -2,7 +2,6 @@
 
 import datetime
 import sys
-import six
 from magicbus.plugins import SimplePlugin
 
 
@@ -10,7 +9,7 @@ class StreamLogger(SimplePlugin):
 
     default_format = '[%(timestamp)s] (Bus %(bus)s) %(message)s\n'
 
-    def __init__(self, bus, stream, level=None, format=None, encoding='utf-8'):
+    def __init__(self, bus, stream, level=None, format=None, encoding=None):
         SimplePlugin.__init__(self, bus)
         self.stream = stream
         self.level = level
@@ -30,27 +29,29 @@ class StreamLogger(SimplePlugin):
             if self.encoding is not None:
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
-            complete_msg = six.ensure_str(complete_msg)
+            else:
+                if not isinstance(complete_msg, unicodestr):
+                    complete_msg = complete_msg.decode("utf-8")
             self.stream.write(complete_msg)
             self.stream.flush()
 
 
 class StdoutLogger(StreamLogger):
 
-    def __init__(self, bus, level=None, format=None, encoding='utf-8'):
+    def __init__(self, bus, level=None, format=None, encoding=None):
         StreamLogger.__init__(self, bus, sys.stdout, level, format, encoding)
 
 
 class StderrLogger(StreamLogger):
 
-    def __init__(self, bus, level=None, format=None, encoding='utf-8'):
+    def __init__(self, bus, level=None, format=None, encoding=None):
         StreamLogger.__init__(self, bus, sys.stderr, level, format, encoding)
 
 
 class FileLogger(StreamLogger):
 
     def __init__(self, bus, filename=None, file=None,
-                 level=None, format=None, encoding='utf8'):
+                 level=None, format=None, encoding=None):
         self.filename = filename
         if file is None:
             if filename is None:

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -37,13 +37,13 @@ class StreamLogger(SimplePlugin):
 
 class StdoutLogger(StreamLogger):
 
-    def __init__(self, bus, level=None, format=None, encoding=None):
+    def __init__(self, bus, level=None, format=None, encoding='utf-8'):
         StreamLogger.__init__(self, bus, sys.stdout, level, format, encoding)
 
 
 class StderrLogger(StreamLogger):
 
-    def __init__(self, bus, level=None, format=None, encoding=None):
+    def __init__(self, bus, level=None, format=None, encoding='utf-8'):
         StreamLogger.__init__(self, bus, sys.stderr, level, format, encoding)
 
 

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -9,7 +9,7 @@ class StreamLogger(SimplePlugin):
 
     default_format = '[%(timestamp)s] (Bus %(bus)s) %(message)s\n'
 
-    def __init__(self, bus, stream, level=None, format=None, encoding='utf8'):
+    def __init__(self, bus, stream, level=None, format=None, encoding='utf-8'):
         SimplePlugin.__init__(self, bus)
         self.stream = stream
         self.level = level
@@ -51,7 +51,7 @@ class StderrLogger(StreamLogger):
 class FileLogger(StreamLogger):
 
     def __init__(self, bus, filename=None, file=None,
-                 level=None, format=None, encoding='utf8'):
+                 level=None, format=None, encoding='utf-8'):
         self.filename = filename
         if file is None:
             if filename is None:

--- a/magicbus/plugins/loggers.py
+++ b/magicbus/plugins/loggers.py
@@ -30,9 +30,8 @@ class StreamLogger(SimplePlugin):
                 if isinstance(complete_msg, str):
                     complete_msg = complete_msg.encode(self.encoding)
             else:
-                if isinstance(complete_msg, str):
-                    encoding = self.encoding or "utf-8"
-                    complete_msg = complete_msg.encode(encoding, errors="backslashreplace")
+                if isinstance(complete_msg, bytes):
+                    complete_msg = complete_msg.decode("utf-8")
 
             self.stream.write(complete_msg)
             self.stream.flush()

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ params = dict(
     ),
     python_requires='>= 3.9',
     install_requires=[
+        'six',
     ],
     extras_require={
         'testing': [

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ params = dict(
     ),
     python_requires='>= 3.9',
     install_requires=[
-        'six',
     ],
     extras_require={
         'testing': [


### PR DESCRIPTION
This includes some content from #11 rebased on `main`. I wasn't able to push this back to that PR for some reason. It's supposed to improve Python 3 compatibility but needs tests.