### PR TITLE
Replace occurrences for www.cherrypy.org to www.cherrypy.dev

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2020, CherryPy Team (team@cherrypy.org)
+Copyright (c) 2004-2020, CherryPy Team (team@cherrypy.dev)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,8 @@ extensions = [
 master_doc = 'index'
 
 intersphinx_mapping = {
-    'cheroot': ('https://cheroot.cherrypy.org/en/latest/', None),
-    'cherrypy': ('https://docs.cherrypy.org/en/latest/', None),
+    'cheroot': ('https://cheroot.cherrypy.dev/en/latest/', None),
+    'cherrypy': ('https://docs.cherrypy.dev/en/latest/', None),
     'python': ('https://docs.python.org/3', None),
     'python2': ('https://docs.python.org/2', None),
 }

--- a/magicbus/plugins/lifecycle.py
+++ b/magicbus/plugins/lifecycle.py
@@ -39,10 +39,10 @@ class ThreadWait(plugins.SimplePlugin):
 
     def EXIT(self):
         # Waiting for ALL child threads to finish is necessary on OS X.
-        # See http://www.cherrypy.org/ticket/581.
+        # See https://github.com/cherrypy/cherrypy/issues/581.
         # It's also good to let them all shut down before allowing
         # the main thread to call atexit handlers.
-        # See http://www.cherrypy.org/ticket/751.
+        # See https://github.com/cherrypy/cherrypy/issues/751.
         self.bus.log('Waiting for child threads to terminate...')
         for t in threading.enumerate():
             if t == threading.current_thread() or not t.is_alive():


### PR DESCRIPTION
As per the discussion [comment](https://github.com/cherrypy/cherrypy/pull/2064#pullrequestreview-2987790351) this PR acknowledges the replacements from `www.cherrypy.org` to `www.cherrypy.dev` domain.

Also, per the discussion/suggestion [here](https://github.com/cherrypy/magicbus/issues/23#issuecomment-3041251870), replaced the License email to `team@cherrypy.dev`.
This PR also replaces the occurrences for below tickets post the new migration to the `github/issues` section of the cherrypy.
- http://www.cherrypy.org/ticket/581
- http://www.cherrypy.org/ticket/751

Resolves #23 